### PR TITLE
Fix Freezing bug

### DIFF
--- a/Source/TCPWrapper/Private/TCPClientComponent.cpp
+++ b/Source/TCPWrapper/Private/TCPClientComponent.cpp
@@ -93,7 +93,7 @@ void UTCPClientComponent::ConnectToSocketAsClient(const FString& InIP /*= TEXT("
 
 		bShouldReceiveData = true;
 
-		while (bShouldReceiveData)
+		while (IsConnected() && bShouldReceiveData)
 		{
 			if (ClientSocket->HasPendingData(BufferSize))
 			{
@@ -148,7 +148,12 @@ void UTCPClientComponent::CloseSocket()
 	if (ClientSocket)
 	{
 		bShouldReceiveData = false;
-		ClientConnectionFinishedFuture.Get();
+		bShouldAttemptConnection = false;
+		
+		if (ClientConnectionFinishedFuture.IsValid())
+		{
+			auto Status = ClientConnectionFinishedFuture.WaitFor(FTimespan::FromSeconds(3.f));
+		}
 
 		ClientSocket->Close();
 		ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM)->DestroySocket(ClientSocket);


### PR DESCRIPTION
After closing the program while tcp client is not connected to the server, it will freeze the program. This will fix it.